### PR TITLE
Upgrade tdr-graph-client

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.3"
   lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.19"
   lazy val generatedGraphql =  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.54"
-  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.14"
+  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.15"
   lazy val mockito = "org.mockito" %% "mockito-scala" % "1.14.1"
   lazy val sqsMock = "io.findify" %% "sqsmock" % "0.3.4"
   lazy val s3Mock = "io.findify" %% "s3mock" % "0.2.6"

--- a/src/test/scala/uk.gov.nationalarchives.fileformat/FileUtilsTest.scala
+++ b/src/test/scala/uk.gov.nationalarchives.fileformat/FileUtilsTest.scala
@@ -16,8 +16,6 @@ import org.scalatest.matchers.should.Matchers._
 import sangria.ast.Document
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.{GetObjectRequest, GetObjectResponse}
-import sttp.client.asynchttpclient.WebSocketHandler
-import sttp.client.asynchttpclient.future.AsyncHttpClientFutureBackend
 import sttp.client.{HttpError, HttpURLConnectionBackend, Identity, NothingT, Response, SttpBackend}
 import sttp.model.StatusCode
 import uk.gov.nationalarchives.tdr.GraphQLClient.Extensions
@@ -90,7 +88,7 @@ class FileUtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with
     val keycloakUtils = mock[KeycloakUtils]
 
     when(keycloakUtils.serviceAccountToken[Identity](any[String], any[String])(any[SttpBackend[Identity, Nothing, NothingT]], any[ClassTag[Identity[_]]]))
-      .thenThrow(HttpError("An error occurred contacting the auth server"))
+      .thenThrow(HttpError("An error occurred contacting the auth server", StatusCode.InternalServerError))
     when(client.getResult[Identity](any[BearerAccessToken], any[Document], any[Option[Variables]])(any[SttpBackend[Identity, Nothing, NothingT]], any[ClassTag[Identity[_]]]))
       .thenReturn(Future.successful(GraphQlResponse(Some(Data(GetClientFileMetadata(Some("originalPath")))), List())))
 


### PR DESCRIPTION
This upgrades the STTP dependency, which requires you to pass in a status code when returning an HTTP error.