### PR TITLE
Hard-code environment ID in test Jenkinsfile

### DIFF
--- a/Jenkinsfile-test
+++ b/Jenkinsfile-test
@@ -1,6 +1,8 @@
 library("tdr-jenkinslib")
 
 lambdaTests(
-        stage: params.STAGE,
+        // Hard-code stage, since it is arbitrary in the lambdaTests
+        // function, which publishes the code to the management account
+        stage: "intg",
         libraryName: "file-format"
 )


### PR DESCRIPTION
The `STAGE` parameter was not being populated correctly since the test build is a multi-branch pipeline, so this fixes broken branch builds.

The environment is arbitrary anyway because the code is always deployed in the management account. The environment parameter is used to choose an IAM role, but the roles currently all have permissions to push code to the release bucket.

This should be updated later to a single role which only has permission to publish to the management account, and this parameter should be removed.