### PR TITLE
Add deploy job name to params.

### DIFF
--- a/Jenkinsfile-test
+++ b/Jenkinsfile-test
@@ -4,5 +4,6 @@ lambdaTests(
         // Hard-code stage, since it is arbitrary in the lambdaTests
         // function, which publishes the code to the management account
         stage: "intg",
-        libraryName: "file-format"
+        libraryName: "file-format",
+        deployJobName: "TDR File Format Deploy"
 )


### PR DESCRIPTION
Because the lambda tests function will be used by different lambdas, I
originally tried to derive the deploy job name from the library name but
this is flaky and annoying so I've changed the lib function here
https://github.com/nationalarchives/tdr-jenkinslib/pull/22
This is currently the only lambda job using this function.