### PR TITLE
Pass in the deployment package name.

### DIFF
--- a/Jenkinsfile-deploy
+++ b/Jenkinsfile-deploy
@@ -3,5 +3,6 @@ library("tdr-jenkinslib")
 deployToLambda(
         stage: params.STAGE,
         libraryName: "file-format",
-        version: params.TO_DEPLOY
+        version: params.TO_DEPLOY,
+        deploymentPackageName: "file-format.jar"
 )


### PR DESCRIPTION
The deployToLambda job was assuming the deployment package was a jar
which isn't always the case. I've changed the job to take a parameter
for the name.
https://github.com/nationalarchives/tdr-jenkinslib/pull/23