### PR TITLE
Log full stack trace of all errors 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ lazy val root = (project in file("."))
       circeCore,
       circeGeneric,
       circeParser,
+      scalaLogging,
       authUtils,
       awsUtils,
       generatedGraphql,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,6 +9,7 @@ object Dependencies {
   lazy val circeCore = "io.circe" %% "circe-core" % "0.13.0"
   lazy val circeGeneric = "io.circe" %% "circe-generic" % "0.13.0"
   lazy val circeParser = "io.circe" %% "circe-parser" % "0.13.0"
+  lazy val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
   lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.3"
   lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.19"
   lazy val generatedGraphql =  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.54"

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/src/main/scala/uk/gov/nationalarchives/fileformat/FileUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/fileformat/FileUtils.scala
@@ -44,8 +44,7 @@ class FileUtils()(implicit val executionContext: ExecutionContext) {
     })
   }
 
-  // TODO: Delete fileId param
-  def writeFileFromS3(path: String, fileId: UUID, record: S3EventNotificationRecord, s3: S3Client): Try[String] = {
+  def writeFileFromS3(path: String, record: S3EventNotificationRecord, s3: S3Client): Try[String] = {
     val s3Obj = record.getS3
     val key = s3Obj.getObject.getKey
     val request = GetObjectRequest

--- a/src/main/scala/uk/gov/nationalarchives/fileformat/FileUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/fileformat/FileUtils.scala
@@ -1,6 +1,5 @@
 package uk.gov.nationalarchives.fileformat
 
-import java.io.File
 import java.net.URLDecoder
 import java.nio.file.Paths
 import java.util.UUID
@@ -10,46 +9,43 @@ import com.typesafe.config.ConfigFactory
 import graphql.codegen.GetOriginalPath.getOriginalPath.{Data, Variables, document}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
-import sttp.client.{HttpURLConnectionBackend, Identity, NothingT, Response, SttpBackend}
-import sttp.client.asynchttpclient.WebSocketHandler
-import sttp.client.asynchttpclient.future.AsyncHttpClientFutureBackend
-import uk.gov.nationalarchives.tdr.error.NotAuthorisedError
-import uk.gov.nationalarchives.tdr.{GraphQLClient, GraphQlResponse}
+import sttp.client.{Identity, NothingT, SttpBackend}
 import uk.gov.nationalarchives.tdr.keycloak.KeycloakUtils
+import uk.gov.nationalarchives.tdr.{GraphQLClient, GraphQlResponse}
 
-import scala.sys.process._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.sys.process._
 import scala.util.Try
 
 class FileUtils()(implicit val executionContext: ExecutionContext) {
 
-  def getFilePath(keycloakUtils: KeycloakUtils, client: GraphQLClient[Data, Variables], fileId: UUID)(implicit backend: SttpBackend[Identity, Nothing, NothingT]): Future[Either[String, String]] = {
+  def getFilePath(keycloakUtils: KeycloakUtils, client: GraphQLClient[Data, Variables], fileId: UUID)(implicit backend: SttpBackend[Identity, Nothing, NothingT]): Future[String] = {
 
     val config = ConfigFactory.load
-    val queryResult: Future[Either[String, GraphQlResponse[Data]]] = (for {
+    val queryResult: Future[GraphQlResponse[Data]] = for {
       token <- keycloakUtils.serviceAccountToken(config.getString("auth.client.id"), config.getString("auth.client.secret"))
       result <- client.getResult(token, document, Option(Variables(fileId)))
-    } yield Right(result)) recover(e => {
-      Left(e.getMessage)
-    })
+    } yield result
 
-    val result = queryResult.map {
-      case Right(response) => response.errors match {
-        case Nil => Right(response.data.get)
-        case List(authError: NotAuthorisedError) => Left(authError.message)
-        case errors => Left(s"GraphQL response contained errors: ${errors.map(e => e.message).mkString}")
+    queryResult.map(graphqlResponse => {
+      graphqlResponse.errors match {
+        case Nil => {
+          val originalPath = graphqlResponse.data.get.getClientFileMetadata.originalPath
+          if (originalPath.getOrElse("").isEmpty) {
+            throw new RuntimeException(s"The original path for file '$fileId' is missing or empty")
+          }
+          originalPath.get
+        }
+        case errors => {
+          val errorSummaries = errors.mkString(", ")
+          throw new RuntimeException(s"Could not find original path for file '$fileId': $errorSummaries")
+        }
       }
-      case Left(e) => Left(e)
-    }
-
-    implicit class OptFunctions(opt: Option[String]) {
-      def toRightNotEmpty(leftMsg: String): Either[String, String] = if (opt.isEmpty || opt.getOrElse("").isEmpty) Left(leftMsg) else Right(opt.get)
-    }
-
-    result.map(_.map(_.getClientFileMetadata.originalPath.toRightNotEmpty("The original path is missing or empty")).flatten)
+    })
   }
 
-  def writeFileFromS3(path: String, fileId: UUID, record: S3EventNotificationRecord, s3: S3Client): Either[String, String] = {
+  // TODO: Delete fileId param
+  def writeFileFromS3(path: String, fileId: UUID, record: S3EventNotificationRecord, s3: S3Client): Try[String] = {
     val s3Obj = record.getS3
     val key = s3Obj.getObject.getKey
     val request = GetObjectRequest
@@ -57,10 +53,10 @@ class FileUtils()(implicit val executionContext: ExecutionContext) {
       .bucket(s3Obj.getBucket.getName)
       .key(URLDecoder.decode(key, "utf-8"))
       .build
-    Try{
+    Try {
       s3.getObject(request, Paths.get(path))
       key
-    }.toEither.left.map(_.getMessage)
+    }
   }
 
   def output(efsRootLocation: String, consignmentId: UUID, originalPath: String, command: String): String =

--- a/src/main/scala/uk/gov/nationalarchives/fileformat/RecordProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/fileformat/RecordProcessor.scala
@@ -38,7 +38,7 @@ class RecordProcessor(sqsUtils: SQSUtils, fileUtils: FileUtils)(implicit val exe
       val writeDirectory = originalPath.split("/").init.mkString("/")
       s"mkdir -p $efsRootLocation/$consignmentId/$writeDirectory".!!
       val writePath = s"$efsRootLocation/$consignmentId/$originalPath"
-      val s3Response: Try[String] = fileUtils.writeFileFromS3(writePath, fileId, record, s3)
+      val s3Response: Try[String] = fileUtils.writeFileFromS3(writePath, record, s3)
 
       s3Response.flatMap(_ => {
         val siegfriedOutput = fileUtils.output(efsRootLocation, consignmentId, originalPath, config.getString("command"))

--- a/src/test/scala/uk.gov.nationalarchives.fileformat/FileUtilsTest.scala
+++ b/src/test/scala/uk.gov.nationalarchives.fileformat/FileUtilsTest.scala
@@ -173,12 +173,11 @@ class FileUtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with
     val pathCaptor: ArgumentCaptor[Path] = ArgumentCaptor.forClass(classOf[Path])
     val mockResponse = GetObjectResponse.builder.build()
     val path = "path"
-    val fileId = UUID.randomUUID()
     val bucket = new S3BucketEntity("bucket", null, "")
     val obj = new S3ObjectEntity("key", null, null, null, null)
     val record = new S3EventNotificationRecord(null, null, null, null, null, null, null, new S3Entity("", bucket, obj, ""), null)
     when(s3Client.getObject(requestCaptor.capture(), pathCaptor.capture())).thenReturn(mockResponse)
-    FileUtils().writeFileFromS3(path, fileId, record, s3Client)
+    FileUtils().writeFileFromS3(path, record, s3Client)
 
     val requestArg = requestCaptor.getValue
     requestArg.bucket should equal("bucket")
@@ -189,12 +188,11 @@ class FileUtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with
   "The writeFileFromS3 method" should "return an error if there is an error writing the file" in {
     val s3Client = mock[S3Client]
     val path = "path"
-    val fileId = UUID.randomUUID()
     val bucket = new S3BucketEntity("bucket", null, "")
     val obj = new S3ObjectEntity("key", null, null, null, null)
     val record = new S3EventNotificationRecord(null, null, null, null, null, null, null, new S3Entity("", bucket, obj, ""), null)
     when(s3Client.getObject(any[GetObjectRequest], any[Path])).thenThrow(new RuntimeException("error"))
-    val response = FileUtils().writeFileFromS3(path, fileId, record, s3Client)
+    val response = FileUtils().writeFileFromS3(path, record, s3Client)
     response.failure.exception should have message "error"
   }
 }

--- a/src/test/scala/uk.gov.nationalarchives.fileformat/RecordProcessorTest.scala
+++ b/src/test/scala/uk.gov.nationalarchives.fileformat/RecordProcessorTest.scala
@@ -5,23 +5,23 @@ import java.util.UUID
 import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification.{S3BucketEntity, S3Entity, S3EventNotificationRecord, S3ObjectEntity}
 import graphql.codegen.GetOriginalPath.getOriginalPath.{Data, Variables}
 import graphql.codegen.types.{FFIDMetadataInput, FFIDMetadataInputMatches}
-import org.mockito.{ArgumentCaptor, MockitoSugar}
+import io.circe.generic.auto._
+import io.circe.parser.decode
+import io.circe.syntax._
 import org.mockito.ArgumentMatchers._
-import org.scalatest.matchers.should.Matchers._
+import org.mockito.{ArgumentCaptor, MockitoSugar}
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.time.{Millis, Seconds, Span}
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse
+import sttp.client.{HttpURLConnectionBackend, Identity, NothingT, SttpBackend}
 import uk.gov.nationalarchives.aws.utils.SQSUtils
 import uk.gov.nationalarchives.fileformat.SiegfriedResponse.{Files, Identifiers, Matches, Siegfried}
 import uk.gov.nationalarchives.tdr.GraphQLClient
 import uk.gov.nationalarchives.tdr.keycloak.KeycloakUtils
-import io.circe.generic.auto._
-import io.circe.parser.decode
-import io.circe.syntax._
-import org.scalatest.time.{Millis, Seconds, Span}
-import software.amazon.awssdk.services.sqs.model.SendMessageResponse
-import sttp.client.{HttpURLConnectionBackend, Identity, NothingT, SttpBackend}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -39,7 +39,7 @@ class RecordProcessorTest extends AnyFlatSpec with MockitoSugar with EitherValue
     val response: String = siegfriedJson.asJson.noSpaces
     when(fileUtils.getFilePath(any[KeycloakUtils], any[GraphQLClient[Data, Variables]], any[UUID])(any[SttpBackend[Identity, Nothing, NothingT]])).thenReturn(Future("originalPath.txt"))
     when(fileUtils.output(any[String], any[UUID], any[String], any[String])).thenReturn(response)
-    when(fileUtils.writeFileFromS3(any[String], any[UUID], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Success("key"))
+    when(fileUtils.writeFileFromS3(any[String], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Success("key"))
 
     val messageCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
     when(sqsUtils.send(any[String], messageCaptor.capture())).thenReturn(SendMessageResponse.builder.build())
@@ -58,7 +58,7 @@ class RecordProcessorTest extends AnyFlatSpec with MockitoSugar with EitherValue
     val response: String = siegfriedJson.asJson.noSpaces
     when(fileUtils.getFilePath(any[KeycloakUtils], any[GraphQLClient[Data, Variables]], any[UUID])(any[SttpBackend[Identity, Nothing, NothingT]])).thenReturn(Future("originalPath.txt"))
     when(fileUtils.output(any[String], any[UUID], any[String], any[String])).thenReturn(response)
-    when(fileUtils.writeFileFromS3(any[String], any[UUID], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Success("key"))
+    when(fileUtils.writeFileFromS3(any[String], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Success("key"))
 
     when(sqsUtils.send(any[String], any[String])).thenReturn(SendMessageResponse.builder.build())
     val record: S3EventNotificationRecord = s3Record(fileId)
@@ -74,7 +74,7 @@ class RecordProcessorTest extends AnyFlatSpec with MockitoSugar with EitherValue
     val response: String = siegfriedJson.asJson.noSpaces
     when(fileUtils.getFilePath(any[KeycloakUtils], any[GraphQLClient[Data, Variables]], any[UUID])(any[SttpBackend[Identity, Nothing, NothingT]])).thenReturn(Future.failed(new RuntimeException("error")))
     when(fileUtils.output(any[String], any[UUID], any[String], any[String])).thenReturn(response)
-    when(fileUtils.writeFileFromS3(any[String], any[UUID], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Success("key"))
+    when(fileUtils.writeFileFromS3(any[String], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Success("key"))
 
     when(sqsUtils.send(any[String], any[String])).thenReturn(SendMessageResponse.builder.build())
     val record: S3EventNotificationRecord = s3Record(fileId)
@@ -90,7 +90,7 @@ class RecordProcessorTest extends AnyFlatSpec with MockitoSugar with EitherValue
     val response: String = siegfriedJson.asJson.noSpaces
     when(fileUtils.getFilePath(any[KeycloakUtils], any[GraphQLClient[Data, Variables]], any[UUID])(any[SttpBackend[Identity, Nothing, NothingT]])).thenReturn(Future("originalPath.txt"))
     when(fileUtils.output(any[String], any[UUID], any[String], any[String])).thenReturn(response)
-    when(fileUtils.writeFileFromS3(any[String], any[UUID], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Failure(new RuntimeException("error")))
+    when(fileUtils.writeFileFromS3(any[String], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Failure(new RuntimeException("error")))
 
     when(sqsUtils.send(any[String], any[String])).thenReturn(SendMessageResponse.builder.build())
     val record: S3EventNotificationRecord = s3Record(fileId)
@@ -106,7 +106,7 @@ class RecordProcessorTest extends AnyFlatSpec with MockitoSugar with EitherValue
 
     when(fileUtils.getFilePath(any[KeycloakUtils], any[GraphQLClient[Data, Variables]], any[UUID])(any[SttpBackend[Identity, Nothing, NothingT]])).thenReturn(Future("originalPath.txt"))
     when(fileUtils.output(any[String], any[UUID], any[String], any[String])).thenReturn("invalidjson")
-    when(fileUtils.writeFileFromS3(any[String], any[UUID], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Success("key"))
+    when(fileUtils.writeFileFromS3(any[String], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Success("key"))
 
     when(sqsUtils.send(any[String], any[String])).thenReturn(SendMessageResponse.builder.build())
     val record: S3EventNotificationRecord = s3Record(fileId)
@@ -122,7 +122,7 @@ class RecordProcessorTest extends AnyFlatSpec with MockitoSugar with EitherValue
     val response: String = siegfriedJson.asJson.noSpaces
     when(fileUtils.getFilePath(any[KeycloakUtils], any[GraphQLClient[Data, Variables]], any[UUID])(any[SttpBackend[Identity, Nothing, NothingT]])).thenReturn(Future("originalPath.txt"))
     when(fileUtils.output(any[String], any[UUID], any[String], any[String])).thenReturn(response)
-    when(fileUtils.writeFileFromS3(any[String], any[UUID], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Success("key"))
+    when(fileUtils.writeFileFromS3(any[String], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Success("key"))
 
     val messageCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
     when(sqsUtils.send(any[String], messageCaptor.capture())).thenReturn(SendMessageResponse.builder.build())
@@ -141,7 +141,7 @@ class RecordProcessorTest extends AnyFlatSpec with MockitoSugar with EitherValue
     val response: String = siegfriedJson.asJson.noSpaces
     when(fileUtils.getFilePath(any[KeycloakUtils], any[GraphQLClient[Data, Variables]], any[UUID])(any[SttpBackend[Identity, Nothing, NothingT]])).thenReturn(Future("originalPath"))
     when(fileUtils.output(any[String], any[UUID], any[String], any[String])).thenReturn(response)
-    when(fileUtils.writeFileFromS3(any[String], any[UUID], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Success("key"))
+    when(fileUtils.writeFileFromS3(any[String], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Success("key"))
 
     val messageCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
     when(sqsUtils.send(any[String], messageCaptor.capture())).thenReturn(SendMessageResponse.builder.build())
@@ -160,7 +160,7 @@ class RecordProcessorTest extends AnyFlatSpec with MockitoSugar with EitherValue
     val response: String = siegfriedJson.asJson.noSpaces
     when(fileUtils.getFilePath(any[KeycloakUtils], any[GraphQLClient[Data, Variables]], any[UUID])(any[SttpBackend[Identity, Nothing, NothingT]])).thenReturn(Future("originalPath"))
     when(fileUtils.output(any[String], any[UUID], any[String], any[String])).thenReturn(response)
-    when(fileUtils.writeFileFromS3(any[String], any[UUID], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Success("key"))
+    when(fileUtils.writeFileFromS3(any[String], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Success("key"))
 
     val messageCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
     when(sqsUtils.send(any[String], messageCaptor.capture())).thenReturn(SendMessageResponse.builder.build())
@@ -184,7 +184,7 @@ class RecordProcessorTest extends AnyFlatSpec with MockitoSugar with EitherValue
 
     when(fileUtils.getFilePath(any[KeycloakUtils], any[GraphQLClient[Data, Variables]], any[UUID])(any[SttpBackend[Identity, Nothing, NothingT]])).thenReturn(Future("originalPath"))
     when(fileUtils.output(any[String], any[UUID], any[String], any[String])).thenReturn(response)
-    when(fileUtils.writeFileFromS3(any[String], any[UUID], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Success("key"))
+    when(fileUtils.writeFileFromS3(any[String], any[S3EventNotificationRecord], any[S3Client])).thenReturn(Success("key"))
 
     val messageCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
     when(sqsUtils.send(any[String], messageCaptor.capture())).thenReturn(SendMessageResponse.builder.build())


### PR DESCRIPTION
The goal of this PR is to make it easier to debug the error we're currently seeing when running the file format lambda, since we currently only get a one-line summary rather than the full stack trace.

Ensure that any errors such as with parsing the message, downloading the file or calling the consignment API are logged, including their full stack trace. This will make it easier to debug errors processing particular messages.

The first commit refactors the error handling to make it possible to log the stack traces.

The final commit deletes an unused method parameter, so it might be easiest to review this PR commit-by-commit.