### PR TITLE
Pass EFS root directory as env variable

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -14,7 +14,9 @@ sqs {
 
 efs {
     root {
+        #Hardcoded value to be removed after update of EFS config
         location = "/mnt/fileformat"
+        location = ${?ROOT_DIRECTORY}
     }
 }
 


### PR DESCRIPTION
Use env variable to make it easier to change EFS root directory

Temporarily retain old hardcoded value until EFS configuration updated to pass in the root directory.