### PR TITLE
Update readme and add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,18 @@
+Copyright (C) 2020 Crown Copyright (The National Archives)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,25 @@
 # File format checks
 
-This is the repository for the backend file format check for the [Transfer Digital Records] project
+This is the repository for the backend file format check for the [Transfer Digital Records] project.
+
+The file format checks run in AWS Lambda. They run the [DROID] file format tool to extract [PRONOM] IDs.
+
+The Lambda function connects to an AWS EFS file store which contains both DROID and the files to be scanned.
+
+DROID and its file signatures are deployed to EFS by an AWS ECS task.
 
 [Transfer Digital Records]: https://github.com/nationalarchives/tdr-dev-documentation/
+[DROID]: https://www.nationalarchives.gov.uk/information-management/manage-information/preserving-digital-records/droid/
+[PRONOM]: http://www.nationalarchives.gov.uk/PRONOM/Default.aspx
 
 ## Deployment
 
-### Siegfried and file format signatures
+### DROID and file format signatures
 
-To deploy changes to the Dockerfile (which installs Siegfried) and the file format signatures, run the "TDR File Format
+To deploy changes to the Dockerfile (which installs DROID) and the file format signatures, run the "TDR File Format
 Build" Jenkins job. This deploys the Docker image to Docker Hub and then runs it as an ECS task.
 
 ### File format Lambda
 
-To deploy changes to the Lambda which downloads the file from S3 and runs Siegfried, run the "TDR File Format Deploy"
+To deploy changes to the Lambda which downloads the file from S3 and runs DROID, run the "TDR File Format Deploy"
 Jenkins job.


### PR DESCRIPTION
Update Readme to explain how the file format check runs. Also replace Siegfried references with DROID. We switched to DROID because Siegfried did not report the expected PRONOM IDs for files which matched multiple signatures.

And add the missing MIT license.