### PR TITLE
Handle folder with quotes

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/fileformat/FFIDExtractor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/fileformat/FFIDExtractor.scala
@@ -30,9 +30,11 @@ class FFIDExtractor(sqsUtils: SQSUtils, config: Config) {
       val containerSignatureVersion = signatureOutput(1).split(" ").last
       val droidSignatureVersion = signatureOutput(2).split(" ").last
       val consignmentPath = s"""$efsRootLocation/${file.consignmentId}"""
-      val filePath = s""""$consignmentPath/${file.originalPath.replaceAll("\"", "\\\\\"")}""""
+      val pathWithQuotesReplaced = file.originalPath.replaceAll(""""""", """\\\"""")
+      val filePath = s""""$consignmentPath/$pathWithQuotesReplaced""""
       //Adds the file to a profile and runs it. The output is a .droid profile file.
-      s"""$command -a  $filePath -p $consignmentPath/${file.fileId}.droid""".!!
+      val droidCommand = s"""$command -a  $filePath -p $consignmentPath/${file.fileId}.droid"""
+      Seq("bash", "-c", droidCommand).!!
       //Exports the profile as a csv
       s"$command -p $consignmentPath/${file.fileId}.droid -E $consignmentPath/${file.fileId}.csv".!!
       val reader = CSVReader.open(new File(s"$consignmentPath/${file.fileId}.csv"))

--- a/src/test/scala/uk.gov.nationalarchives.fileformat/FFIDExtractorTest.scala
+++ b/src/test/scala/uk.gov.nationalarchives.fileformat/FFIDExtractorTest.scala
@@ -54,5 +54,5 @@ class FFIDExtractorTest extends FileSpec {
     Map("command" -> s"test.sh $commandArg.csv", "efs.root.location" -> "./src/test/resources/testfiles", "sqs.queue.output" -> "output").asJava
   )
   def ffidFile: FFIDFile = FFIDFile(UUID.fromString("f0a73877-6057-4bbb-a1eb-7c7b73cab586"), UUID.fromString("acea5919-25a3-4c6b-8908-fa47cc77878f"), "originalPath")
-  def ffidFileWithQuote: FFIDFile = FFIDFile(UUID.fromString("f0a73877-6057-4bbb-a1eb-7c7b73cab586"), UUID.fromString("acea5919-25a3-4c6b-8908-fa47cc77878f"), """originalPath"withQuote""")
+  def ffidFileWithQuote: FFIDFile = FFIDFile(UUID.fromString("f0a73877-6057-4bbb-a1eb-7c7b73cab586"), UUID.fromString("acea5919-25a3-4c6b-8908-fa47cc77878f"), """rootDirectory/originalPath"withQu'ote""")
 }

--- a/src/test/scala/uk.gov.nationalarchives.fileformat/FFIDExtractorTest.scala
+++ b/src/test/scala/uk.gov.nationalarchives.fileformat/FFIDExtractorTest.scala
@@ -44,9 +44,15 @@ class FFIDExtractorTest extends FileSpec {
     result.left.value.err.getMessage should equal("Nonzero exit value: 1")
   }
 
+  "The ffid method" should "return a correct value if there are quotes in the filename" in {
+    val result = FFIDExtractor(sqsUtils, config("result_one_record")).ffidFile(ffidFileWithQuote)
+    result.isRight should be (true)
+  }
+
   def sqsUtils: SQSUtils = mock[SQSUtils]
   def config(commandArg: String): Config = ConfigFactory.parseMap(
     Map("command" -> s"test.sh $commandArg.csv", "efs.root.location" -> "./src/test/resources/testfiles", "sqs.queue.output" -> "output").asJava
   )
   def ffidFile: FFIDFile = FFIDFile(UUID.fromString("f0a73877-6057-4bbb-a1eb-7c7b73cab586"), UUID.fromString("acea5919-25a3-4c6b-8908-fa47cc77878f"), "originalPath")
+  def ffidFileWithQuote: FFIDFile = FFIDFile(UUID.fromString("f0a73877-6057-4bbb-a1eb-7c7b73cab586"), UUID.fromString("acea5919-25a3-4c6b-8908-fa47cc77878f"), """originalPath"withQuote""")
 }

--- a/src/test/scala/uk.gov.nationalarchives.fileformat/FileSpec.scala
+++ b/src/test/scala/uk.gov.nationalarchives.fileformat/FileSpec.scala
@@ -13,6 +13,7 @@ trait FileSpec extends AnyFlatSpec with BeforeAndAfterEach  with MockitoSugar wi
   override def beforeEach(): Unit = {
     "mkdir -p ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/rootDirectory/subDirectory".!
     "touch ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/originalPath".!
+    """touch './src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/originalPath"withQuote'""".!
     """touch "./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/path with space" """.!
     "touch ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/rootDirectory/subDirectory/originalPath".!
   }

--- a/src/test/scala/uk.gov.nationalarchives.fileformat/FileSpec.scala
+++ b/src/test/scala/uk.gov.nationalarchives.fileformat/FileSpec.scala
@@ -13,7 +13,7 @@ trait FileSpec extends AnyFlatSpec with BeforeAndAfterEach  with MockitoSugar wi
   override def beforeEach(): Unit = {
     "mkdir -p ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/rootDirectory/subDirectory".!
     "touch ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/originalPath".!
-    """touch "./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/rootDirectory/originalPath\"withQu'ote"""".!!
+    Seq("bash", "-c", """touch "./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/rootDirectory/originalPath\"withQu'ote"""").!!
     """touch "./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/path with space" """.!
     "touch ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/rootDirectory/subDirectory/originalPath".!
   }

--- a/src/test/scala/uk.gov.nationalarchives.fileformat/FileSpec.scala
+++ b/src/test/scala/uk.gov.nationalarchives.fileformat/FileSpec.scala
@@ -13,7 +13,7 @@ trait FileSpec extends AnyFlatSpec with BeforeAndAfterEach  with MockitoSugar wi
   override def beforeEach(): Unit = {
     "mkdir -p ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/rootDirectory/subDirectory".!
     "touch ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/originalPath".!
-    """touch './src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/originalPath"withQuote'""".!
+    """touch "./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/rootDirectory/originalPath\"withQu'ote"""".!!
     """touch "./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/path with space" """.!
     "touch ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/rootDirectory/subDirectory/originalPath".!
   }


### PR DESCRIPTION
Put the path in quotes and then escape any double quotes. The double quotes handle any other special characters and the escaping handles any double quotes in the path.

