### PR TITLE
Allow backtick in filename

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/fileformat/FFIDExtractor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/fileformat/FFIDExtractor.scala
@@ -30,7 +30,9 @@ class FFIDExtractor(sqsUtils: SQSUtils, config: Config) {
       val containerSignatureVersion = signatureOutput(1).split(" ").last
       val droidSignatureVersion = signatureOutput(2).split(" ").last
       val consignmentPath = s"""$efsRootLocation/${file.consignmentId}"""
-      val pathWithQuotesReplaced = file.originalPath.replaceAll(""""""", """\\\"""")
+      val pathWithQuotesReplaced = file.originalPath
+        .replaceAll(""""""", """\\\"""")
+        .replaceAll("`", "\\\\`")
       val filePath = s""""$consignmentPath/$pathWithQuotesReplaced""""
       //Adds the file to a profile and runs it. The output is a .droid profile file.
       val droidCommand = s"""$command -a  $filePath -p $consignmentPath/${file.fileId}.droid"""

--- a/src/test/resources/json/sns_ffid_path_with_backtick_event.json
+++ b/src/test/resources/json/sns_ffid_path_with_backtick_event.json
@@ -1,0 +1,1 @@
+{"consignmentId":  "f0a73877-6057-4bbb-a1eb-7c7b73cab586", "fileId":  "acea5919-25a3-4c6b-8908-fa47cc77878f", "originalPath" :  "pathwith`"}

--- a/src/test/scala/uk.gov.nationalarchives.fileformat/FileSpec.scala
+++ b/src/test/scala/uk.gov.nationalarchives.fileformat/FileSpec.scala
@@ -13,6 +13,7 @@ trait FileSpec extends AnyFlatSpec with BeforeAndAfterEach  with MockitoSugar wi
   override def beforeEach(): Unit = {
     "mkdir -p ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/rootDirectory/subDirectory".!
     "touch ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/originalPath".!
+    "touch ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/pathwith`".!!
     Seq("bash", "-c", """touch "./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/rootDirectory/originalPath\"withQu'ote"""").!!
     """touch "./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/path with space" """.!
     "touch ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/rootDirectory/subDirectory/originalPath".!

--- a/src/test/scala/uk.gov.nationalarchives.fileformat/LambdaTest.scala
+++ b/src/test/scala/uk.gov.nationalarchives.fileformat/LambdaTest.scala
@@ -75,4 +75,14 @@ class LambdaTest extends SqsSpec with FileSpec {
     }
     metadata.fileId should equal(UUID.fromString("acea5919-25a3-4c6b-8908-fa47cc77878f"))
   }
+
+  "The update method" should "send the correct output if the path has backticks" in {
+    new Lambda().process(createEvent("sns_ffid_path_with_backtick_event"), null)
+    val msgs = outputQueueHelper.receive
+    val metadata: FFIDMetadataInput = decode[FFIDMetadataInput](msgs(0).body) match {
+      case Right(metadata) => metadata
+      case Left(error) => throw error
+    }
+    metadata.fileId should equal(UUID.fromString("acea5919-25a3-4c6b-8908-fa47cc77878f"))
+  }
 }


### PR DESCRIPTION
The lambda was failing if there was a backtick in the name because this
won't work within a quoted filename. I've replaced  with \\` and this is
ok now.
