### PR TITLE
Make sure that every before-and-after step is run in tests

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.1.1"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.9"
   lazy val typesafe = "com.typesafe" % "config" % "1.4.0"
   lazy val s3Sdk = "software.amazon.awssdk" % "s3" % "2.13.18"
   lazy val lambdaJavaCore = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"

--- a/src/test/scala/uk.gov.nationalarchives.fileformat/AWSSpec.scala
+++ b/src/test/scala/uk.gov.nationalarchives.fileformat/AWSSpec.scala
@@ -1,13 +1,12 @@
 package uk.gov.nationalarchives.fileformat
 
 import com.github.tomakehurst.wiremock.client.WireMock.{post, urlEqualTo}
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 import uk.gov.nationalarchives.fileformat.AWSUtils._
 
 import scala.language.postfixOps
 
-class AWSSpec extends AnyFlatSpec with BeforeAndAfterEach with BeforeAndAfterAll {
+trait AWSSpec extends BeforeAndAfterEach with BeforeAndAfterAll { this: Suite =>
 
   override def beforeAll(): Unit = {
     wiremockKmsEndpoint.start()
@@ -15,14 +14,20 @@ class AWSSpec extends AnyFlatSpec with BeforeAndAfterEach with BeforeAndAfterAll
     api.start()
     inputQueueHelper.createQueue
     outputQueueHelper.createQueue
+
+    super.beforeAll()
   }
 
   override def afterAll(): Unit = {
+    super.afterAll()
+
     wiremockKmsEndpoint.stop()
     api.shutdown
   }
 
   override def afterEach(): Unit = {
+    super.afterEach()
+
     inputQueueHelper.receive.foreach(inputQueueHelper.delete)
     outputQueueHelper.receive.foreach(inputQueueHelper.delete)
   }

--- a/src/test/scala/uk.gov.nationalarchives.fileformat/FFIDExtractorTest.scala
+++ b/src/test/scala/uk.gov.nationalarchives.fileformat/FFIDExtractorTest.scala
@@ -2,11 +2,14 @@ package uk.gov.nationalarchives.fileformat
 
 import java.util.UUID
 
+import org.mockito.MockitoSugar
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 import uk.gov.nationalarchives.aws.utils.SQSUtils
 import uk.gov.nationalarchives.fileformat.FFIDExtractor.FFIDFile
 
-class FFIDExtractorTest extends FileSpec {
+class FFIDExtractorTest extends AnyFlatSpec with FileSpec with MockitoSugar with EitherValues {
 
   "The ffid method" should "return the correct droid and signature version" in {
     val result = FFIDExtractor(sqsUtils, config("result_some_parent_ids")).ffidFile(ffidFile)

--- a/src/test/scala/uk.gov.nationalarchives.fileformat/FileSpec.scala
+++ b/src/test/scala/uk.gov.nationalarchives.fileformat/FileSpec.scala
@@ -1,12 +1,10 @@
 package uk.gov.nationalarchives.fileformat
 
-import org.mockito.MockitoSugar
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.{BeforeAndAfterEach, EitherValues}
+import org.scalatest.{BeforeAndAfterEach, Suite}
 
 import scala.sys.process._
 
-trait FileSpec extends AnyFlatSpec with BeforeAndAfterEach  with MockitoSugar with EitherValues {
+trait FileSpec extends BeforeAndAfterEach { this: Suite =>
 
   // Create the files and then try to ls them in the test script. This mimics reading from the existing file on EFS
   // and should catch problems where there are spaces in the filename.
@@ -17,9 +15,13 @@ trait FileSpec extends AnyFlatSpec with BeforeAndAfterEach  with MockitoSugar wi
     Seq("bash", "-c", """touch "./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/rootDirectory/originalPath\"withQu'ote"""").!!
     """touch "./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/path with space" """.!
     "touch ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/rootDirectory/subDirectory/originalPath".!
+
+    super.beforeEach()
   }
 
   override def afterEach(): Unit = {
+    super.afterEach()
+
     "rm -rf ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586".!
   }
 }

--- a/src/test/scala/uk.gov.nationalarchives.fileformat/LambdaTest.scala
+++ b/src/test/scala/uk.gov.nationalarchives.fileformat/LambdaTest.scala
@@ -4,10 +4,11 @@ import java.util.UUID
 
 import graphql.codegen.types.FFIDMetadataInput
 import io.circe.parser.decode
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers.{equal, _}
 import uk.gov.nationalarchives.fileformat.AWSUtils._
 
-class LambdaTest extends AWSSpec with FileSpec {
+class LambdaTest extends AnyFlatSpec with AWSSpec with FileSpec {
 
   "The update method" should "put a message in the output queue if the message is successful " in {
     new Lambda().process(createEvent("sns_ffid_event"), null)


### PR DESCRIPTION
Before, when multiple traits were mixed into a test, only one set of `beforeEach` (or similar) methods was run, because it over-rode the the method from the other mixin.

Fix this by adding a call to `super` to every before or after method, so that all of the setup and destroy steps are run.

Follow the ScalaTest advice in https://www.scalatest.org/user_guide/sharing_fixtures to call `super.beforeEach` at the end of the method and `super.afterEach` at the start of the method.

This didn't seem to be causing any problems before, but it is necessary for an upcoming change where we switch to ElasticMQ. Without this change, the steps to create the queue in `beforeEach` would be skipped.