### PR TITLE
Reset message visibility if an error happens when running FFID check 

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
-  lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.15"
+  lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.16"
   lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.19"
   lazy val generatedGraphql =  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.60"
   lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.15"

--- a/src/test/resources/json/sns_ffid_missing_file.json
+++ b/src/test/resources/json/sns_ffid_missing_file.json
@@ -1,0 +1,1 @@
+{"consignmentId":  "f0a73877-6057-4bbb-a1eb-7c7b73cab586", "fileId":  "acea5919-25a3-4c6b-8908-fa47cc77878f", "originalPath" :  "nonExistentFile"}

--- a/src/test/scala/uk.gov.nationalarchives.fileformat/FFIDExtractorTest.scala
+++ b/src/test/scala/uk.gov.nationalarchives.fileformat/FFIDExtractorTest.scala
@@ -41,7 +41,8 @@ class FFIDExtractorTest extends AnyFlatSpec with FileSpec with MockitoSugar with
 
   "The ffid method" should "return an error if there is an error running the droid commands" in {
     val result = FFIDExtractor(sqsUtils, config("invalid_command")).ffidFile(ffidFile)
-    result.left.value.err.getMessage should equal("Nonzero exit value: 1")
+    result.left.value.getMessage should equal("Error processing file id acea5919-25a3-4c6b-8908-fa47cc77878f with original path originalPath")
+    result.left.value.getCause.getMessage should equal("Nonzero exit value: 1")
   }
 
   "The ffid method" should "return a correct value if there are quotes in the filename" in {


### PR DESCRIPTION
This makes Lambda retries faster. They had become much slower when we increased the SQS message visibility to be three times the length of the Lambda timeout: https://github.com/nationalarchives/tdr-dev-documentation/blob/master/architecture-decision-records/0020-sqs-visibility-timeout.md

This change means that the retry happens immediately, not when the message has expired after 45 minutes.

The message visibility reset only happens if an error is encountered when running the FFID check. If the error happens before the SQS message is parsed, we do not have a receipt handle available to reset the visibility.

Also refactor the ErrorSummary class to make it easier to add the extra error handling. ErrorSummary contained a message and a Throwable, so it was effectively just another Throwable. Replacing it with Throwable makes it easier to add extra error handling which contains the message receipt, because we don't have to add yet another wrapper class for ErrorSummary.