### PR TITLE
Format logs as JSON 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ lazy val root = (project in file("."))
       graphqlClient,
       scalaLogging,
       logback,
+      logstashLogbackEncoder,
       scalaTest % Test,
       mockito % Test,
       elasticMq % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,6 +19,7 @@ object Dependencies {
   lazy val csvParser = "com.github.tototoshi" %% "scala-csv" % "1.3.6"
   lazy val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
   lazy val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
+  lazy val logstashLogbackEncoder = "net.logstash.logback" % "logstash-logback-encoder" % "6.6"
   lazy val mockito = "org.mockito" %% "mockito-scala" % "1.14.1"
   lazy val elasticMq = "org.elasticmq" %% "elasticmq-server" % elasticMqVersion
   lazy val elasticMqSqs = "org.elasticmq" %% "elasticmq-rest-sqs" % elasticMqVersion

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    <appender name="json" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"application":"tdr-api-update"}</customFields>
         </encoder>
     </appender>
 
     <root level="info">
-        <appender-ref ref="STDOUT" />
+        <appender-ref ref="json" />
     </root>
 </configuration>


### PR DESCRIPTION
This makes it easier to search logs because CloudWatch Insights can search by JSON field keys.

The long-term goal is to convert all logging to JSON: https://national-archives.atlassian.net/browse/TDR-894

Also add some structured logging to let us check the number of matches found, since DROID should always output at least one match but we have caught some cases where there are no matches in the database.