### PR TITLE
Ensure file format build process builds Docker image once

### DIFF
--- a/Jenkinsfile-build
+++ b/Jenkinsfile-build
@@ -1,22 +1,27 @@
 library("tdr-jenkinslib")
 
-def repo = "tdr-file-format"
 pipeline {
   agent none
 
   parameters {
     choice(name: "STAGE", choices: ["intg", "staging", "prod"], description: "The stage you are building the file format lambda for")
+    string(name: "TO_DEPLOY", description: "The git tag, branch or commit reference to deploy, e.g. 'v123'")
   }
 
   stages {
-    stage("Push Docker image") {
+    stage("Tag Docker image") {
       agent {
         label "built-in"
       }
       steps {
         script {
-          tdr.buildAndPushImage("file-format-build", params.STAGE)
-          tdr.postToDaTdrSlackChannel(colour: "good", message: "*File Format Build* :whale: Pushed container for ${params:STAGE} to AWS ECR")
+          def image = "${env.MANAGEMENT_ACCOUNT}.dkr.ecr.eu-west-2.amazonaws.com/file-format-build"
+          sh "aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${env.MANAGEMENT_ACCOUNT}.dkr.ecr.eu-west-2.amazonaws.com"
+          sh "docker pull ${image}:${params.TO_DEPLOY}"
+          sh "docker tag ${image}:${params.TO_DEPLOY} ${image}:${params.STAGE}"
+          sh "docker push ${image}:${params.STAGE}"
+
+          tdr.postToDaTdrSlackChannel(colour: "good", message: "*file-format-build* :whale: The '${params.TO_DEPLOY}' image has been tagged with '${params.STAGE}' in ECR")
         }
       }
     }
@@ -37,4 +42,3 @@ pipeline {
     }
   }
 }
-

--- a/Jenkinsfile-deploy
+++ b/Jenkinsfile-deploy
@@ -1,8 +1,8 @@
 library("tdr-jenkinslib")
 
 deployToLambda(
-        stage: params.STAGE,
-        libraryName: "file-format",
-        version: params.TO_DEPLOY,
-        deploymentPackageName: "file-format.jar"
+  stage: params.STAGE,
+  libraryName: "file-format",
+  version: params.TO_DEPLOY,
+  deploymentPackageName: "file-format.jar"
 )

--- a/Jenkinsfile-test
+++ b/Jenkinsfile-test
@@ -1,9 +1,117 @@
 library("tdr-jenkinslib")
 
-lambdaTests(
-        // Hard-code stage, since it is arbitrary in the lambdaTests
-        // function, which publishes the code to the management account
-        stage: "intg",
-        libraryName: "file-format",
-        deployJobName: "TDR File Format Deploy"
-)
+def versionTag = "v${env.BUILD_NUMBER}"
+def libraryName = "file-format"
+def repo = "tdr-file-format"
+
+pipeline {
+  agent {
+    label "built-in"
+  }
+  stages {
+    stage("Run git secrets") {
+      steps {
+        script {
+          tdr.runGitSecrets(repo)
+        }
+      }
+    }
+    stage("Build lambda") {
+      agent {
+        ecs {
+          inheritFrom "transfer-frontend"
+          taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/sbtwithpostgres"
+        }
+      }
+      steps {
+        script {
+          tdr.reportStartOfBuildToGitHub(repo, env.GIT_COMMIT)
+          tdr.assembleAndStash(${libraryName})
+        }
+      }
+    }
+    stage('Post-build') {
+      when {
+        beforeAgent true
+        expression { ["main", "master"].contains(env.BRANCH_NAME) }
+      }
+      stages {
+        stage('Tag Release') {
+          steps {
+            sh "git tag ${versionTag}"
+            sshagent(['github-jenkins']) {
+              sh("git push origin ${versionTag}")
+            }
+          }
+        }
+        stage("Push Docker image") {
+          steps {
+            script {
+              tdr.buildAndPushImage("file-format-build", ${versionTag})
+              tdr.postToDaTdrSlackChannel(colour: "good", message: "*File Format Build* :whale: Pushed version ${versionTag} to AWS ECR")
+
+              build(
+                job: "TDR File Format Build",
+                parameters: [
+                  string(name: "STAGE", value: "intg"),
+                  string(name: "TO_DEPLOY", value: versionTag)
+                ]
+              )
+            }
+          }
+        }
+        stage('Deploy lambda to integration') {
+          agent {
+            ecs {
+              inheritFrom "aws"
+              taskrole "arn:aws:iam::${env.MANAGEMENT_ACCOUNT}:role/TDRJenkinsNodeLambdaRoleIntg"
+            }
+          }
+          steps {
+            script {
+              unstash "${libraryName}-jar"
+              tdr.copyToS3CodeBucket(libraryName, versionTag)
+
+              tdr.configureJenkinsGitUser()
+
+              build(
+                job: "TDR File Format Deploy",
+                parameters: [
+                  string(name: "STAGE", value: "intg"),
+                  string(name: "TO_DEPLOY", value: versionTag)
+                ],
+                wait: false)
+            }
+          }
+        }
+      }
+    }
+  }
+  post {
+    failure {
+      script {
+        tdr.reportFailedBuildToGitHub(repo, env.GIT_COMMIT)
+
+        if (["main", "master"].contains(env.BRANCH_NAME)) {
+          tdr.postToDaTdrSlackChannel(colour: "danger",
+            message: "*${config.libraryName}* :warning: ${env.BRANCH_NAME.capitalize()} branch build failed: ${env.BUILD_URL}"
+          )
+        }
+      }
+    }
+    unstable {
+      script {
+        if (["main", "master"].contains(env.BRANCH_NAME)) {
+          tdr.postToDaTdrSlackChannel(colour: "warning",
+            message: "*${config.libraryName}* :warning: ${env.BRANCH_NAME.capitalize()} branch build marked as unstable: ${env.BUILD_URL}"
+          )
+        }
+      }
+    }
+    success {
+      script {
+        tdr.reportSuccessfulBuildToGitHub(repo, env.GIT_COMMIT)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Build process as follows
1. Jenkinsfile-test:
- builds lambda
- if main branch
-- tags release
-- builds and pushes Docker image with release tag
-- deploys Docker image to intg via Jenkinsfile-build job
-- deploys lambda to intg via Jenkinsfile-deploy job
2. Jenkinsfile-build
- tags the release version of the image with the appropriate TDR env tag
- deploys the latest image to EFS via the ECS task to the TDR env
3. Jenkinsfile-deploy
- deploys the latest lambda code to the appropriate TDR env

The Docker image is built and deployed first to ensure the lambda uses the most up-to-date version of DROID / Pronom signatures