### PR TITLE
Update DROID version to 6.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ RUN addgroup --system fileformatgroup && adduser --system fileformatuser -G file
 RUN apk update \
     && apk add git unzip wget \
     && apk upgrade apk-tools busybox
-RUN wget -qq https://github.com/digital-preservation/droid/releases/download/droid-6.5/droid-binary-6.5-bin.zip
+RUN wget -qq https://cdn.nationalarchives.gov.uk/documents/droid-binary-6.5.1-bin.zip
 COPY droid.sh /
 
 USER fileformatuser
-CMD unzip -o -d /tmp/fileformatbuild droid-binary-6.5-bin.zip && cp /droid.sh /tmp/fileformatbuild/droid
+CMD unzip -o -d /tmp/fileformatbuild droid-binary-6.5.1-bin.zip && cp /droid.sh /tmp/fileformatbuild/droid


### PR DESCRIPTION
New version of DROID fixes the Log4j vulnerability

The URL used to retrieve the binary is changed as there currently is not a binary available via GitHub