### PR TITLE
Use droid 6.5.2

### DIFF
--- a/droid.sh
+++ b/droid.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-java -Xmx512m -DdroidTempDir=/mnt/backend-checks -DdroidLogDir=/mnt/backend-checks -DdroidUserDir=/mnt/backend-checks -jar "/mnt/backend-checks/droid-command-line-6.5.jar" "$@"
+java -Xmx512m -DdroidTempDir=/mnt/backend-checks -DdroidLogDir=/mnt/backend-checks -DdroidUserDir=/mnt/backend-checks -jar "/mnt/backend-checks/droid-command-line-6.5.2.jar" "$@"
 


### PR DESCRIPTION
When we run the file format build, it doesn't remove the older versions
of droid so droid-command-line-6.5.jar still exists but we should be
using the 6.5.2 version. This should update it and then we'll need to
run the file-format-build again.
