### PR TITLE
Pin the droid version.

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -9,3 +9,8 @@ signatures {
   nationalArchivesUrl = "https://www.nationalarchives.gov.uk"
 }
 root.directory="/tmp"
+droid {
+  pin=true
+  pin=${?PIN_DROID_VERSION}
+  version=109
+}

--- a/src/main/scala/uk/gov/nationalarchives/fileformat/SignatureFiles.scala
+++ b/src/main/scala/uk/gov/nationalarchives/fileformat/SignatureFiles.scala
@@ -3,6 +3,7 @@ package uk.gov.nationalarchives.fileformat
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.Logger
 import org.w3c.dom.Document
+import uk.gov.nationalarchives.fileformat.FFIDExtractor.configFactory
 import uk.gov.nationalarchives.fileformat.SignatureFiles._
 
 import java.io._
@@ -31,7 +32,11 @@ class SignatureFiles(client: HttpClient, existingFiles: List[File]) {
       val fileName = if (fileType == "container") {
         s"$containerSignaturePrefix${containerSignatureVersion()}.xml"
       } else {
-        s"$droidSignaturePrefix${droidSignatureVersion()}.xml"
+        if(configFactory.getBoolean("droid.pin")) {
+          s"$droidSignaturePrefix${configFactory.getString("droid.version")}.xml"
+        } else {
+          s"$droidSignaturePrefix${droidSignatureVersion()}.xml"
+        }
       }
 
       val path = Paths.get(s"$rootDirectory/$fileName")

--- a/src/main/scala/uk/gov/nationalarchives/fileformat/SignatureFiles.scala
+++ b/src/main/scala/uk/gov/nationalarchives/fileformat/SignatureFiles.scala
@@ -3,7 +3,6 @@ package uk.gov.nationalarchives.fileformat
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.Logger
 import org.w3c.dom.Document
-import uk.gov.nationalarchives.fileformat.FFIDExtractor.configFactory
 import uk.gov.nationalarchives.fileformat.SignatureFiles._
 
 import java.io._
@@ -32,8 +31,8 @@ class SignatureFiles(client: HttpClient, existingFiles: List[File]) {
       val fileName = if (fileType == "container") {
         s"$containerSignaturePrefix${containerSignatureVersion()}.xml"
       } else {
-        if(configFactory.getBoolean("droid.pin")) {
-          s"$droidSignaturePrefix${configFactory.getString("droid.version")}.xml"
+        if(config.getBoolean("droid.pin")) {
+          s"$droidSignaturePrefix${config.getString("droid.version")}.xml"
         } else {
           s"$droidSignaturePrefix${droidSignatureVersion()}.xml"
         }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -9,3 +9,7 @@ signatures {
 }
 
 root.directory="./src/test/resources/testfiles/running-files"
+
+droid {
+  pin=false
+}


### PR DESCRIPTION
There is an issue with the new Droid version 110 which is causing the
file format lambda to fail. We always automatically download the latest
version. This will pin it to 109 which is the last known working version.

I've set an environment variable so that we can stop pinning the version
wiht an environment variable so we can test it and revert it if we need
to.
