### PR TITLE
TDR-3367 - Update file format lambda to pass mismatch value from DROID api

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
   lazy val s3Utils =  "uk.gov.nationalarchives" %% "s3-utils" % "0.1.95"
-  lazy val generatedGraphql =  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.338"
+  lazy val generatedGraphql =  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.341"
   lazy val csvParser = "com.github.tototoshi" %% "scala-csv" % "1.3.10"
   lazy val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5"
   lazy val logback = "ch.qos.logback" % "logback-classic" % "1.4.8"
@@ -18,7 +18,7 @@ object Dependencies {
   lazy val mockito = "org.mockito" %% "mockito-scala" % "1.17.14"
   lazy val wiremock = "com.github.tomakehurst" % "wiremock" % "2.27.2"
   lazy val apacheCommons = "org.apache.commons" % "commons-lang3" % "3.12.0"
-  lazy val droidApi = "uk.gov.nationalarchives" % "droid-api" % "6.6.1"
+  lazy val droidApi = "uk.gov.nationalarchives" % "droid-api" % "6.7.0-RC3"
   // This is an older version of this dependency but the newer version won't work with Droid without some major changes.
   // Scala Steward configured to ignore it.
   lazy val javaxXml =  "org.glassfish.jaxb" % "jaxb-runtime" % "2.3.7"

--- a/src/test/scala/uk/gov/nationalarchives/fileformat/FFIDExtractorTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/fileformat/FFIDExtractorTest.scala
@@ -58,6 +58,17 @@ class FFIDExtractorTest extends AnyFlatSpec with MockitoSugar with EitherValues 
     m.fileExtensionMismatch.contains(true)
   }
 
+  "the ffid method" should "return a file format name if one exists" in {
+    val api = mock[DroidAPI]
+    val mockResult = new ApiResult(null, IdentificationMethod.EXTENSION, null, ".formatName", true)
+    when(api.submit(any[Path])).thenReturn(List(mockResult).asJava)
+
+    val result = new FFIDExtractor(api, rootDirectory).ffidFile(ffidFile)
+    val ffid = result.right.value
+    val m = ffid.matches.head
+    m.formatName.contains(".formatName")
+  }
+
   "The ffid method" should "return more than one result for multiple result rows" in {
     val api = mock[DroidAPI]
     val apiResults = for {

--- a/src/test/scala/uk/gov/nationalarchives/fileformat/FFIDExtractorTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/fileformat/FFIDExtractorTest.scala
@@ -37,7 +37,7 @@ class FFIDExtractorTest extends AnyFlatSpec with MockitoSugar with EitherValues 
 
   "The ffid method" should "return the correct value if the extension and puid are empty" in {
     val api = mock[DroidAPI]
-    val mockResult = new ApiResult(null, IdentificationMethod.EXTENSION, null, "testName")
+    val mockResult = new ApiResult(null, IdentificationMethod.EXTENSION, null, "testName", false)
     when(api.submit(any[Path])).thenReturn(List(mockResult).asJava)
 
     val result = new FFIDExtractor(api, rootDirectory).ffidFile(ffidFile)
@@ -47,11 +47,22 @@ class FFIDExtractorTest extends AnyFlatSpec with MockitoSugar with EitherValues 
     m.puid.isEmpty should be(true)
   }
 
+  "the ffid method" should "return a file extension mismatch if one exists" in {
+    val api = mock[DroidAPI]
+    val mockResult = new ApiResult(null, IdentificationMethod.EXTENSION, null, "testName", true)
+    when(api.submit(any[Path])).thenReturn(List(mockResult).asJava)
+
+    val result = new FFIDExtractor(api, rootDirectory).ffidFile(ffidFile)
+    val ffid = result.right.value
+    val m = ffid.matches.head
+    m.fileExtensionMismatch.contains(true)
+  }
+
   "The ffid method" should "return more than one result for multiple result rows" in {
     val api = mock[DroidAPI]
     val apiResults = for {
       count <- List("1", "2", "3")
-      res <- new ApiResult(s"extension$count", IdentificationMethod.EXTENSION, s"puid$count", s"testName$count") :: Nil
+      res <- new ApiResult(s"extension$count", IdentificationMethod.EXTENSION, s"puid$count", s"testName$count", false) :: Nil
     } yield res
 
     when(api.submit(any[Path])).thenReturn(apiResults.asJava)
@@ -75,10 +86,12 @@ class FFIDExtractorTest extends AnyFlatSpec with MockitoSugar with EitherValues 
     when(api.submit(any[Path])).thenReturn(List().asJava)
 
     val result = new FFIDExtractor(api, rootDirectory).ffidFile(ffidFileWithQuote)
-    result.isRight should be (true)
+    result.isRight should be(true)
   }
 
   val userId: UUID = UUID.randomUUID()
+
   def ffidFile: FFIDFile = FFIDFile(UUID.randomUUID(), UUID.randomUUID(), "originalPath", userId)
+
   def ffidFileWithQuote: FFIDFile = FFIDFile(UUID.randomUUID(), UUID.randomUUID(), """rootDirectory/originalPath"withQu'ote""", userId)
 }


### PR DESCRIPTION
[TDR-3367](https://national-archives.atlassian.net/browse/TDR-3367?atlOrigin=eyJpIjoiYmVmODQ4ZTRmOGEyNGJjOTk3Y2VmN2Q2Y2U3Y2Y1MGUiLCJwIjoiaiJ9)

- [x] Altered API
- [x] Altered old tests
- [x] Added additional test

[TDR-3367]: https://national-archives.atlassian.net/browse/TDR-3367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ