### PR TITLE
Manually bump to the latest DROID binary version

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -10,5 +10,5 @@ signatures {
 }
 root.directory="/tmp"
 
-droid.version="111"
+droid.version="116"
 containers.version="20231127"


### PR DESCRIPTION
Github action running on CRON job should be picking up latest versions.

The action is running successfully but failing to pick up changes to the versions. Raised this issue as a bug: https://national-archives.atlassian.net/browse/TDR-3676

As a temporary expedient manually bumping