### PR TITLE
Require zero argument constructor for Lambdas

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/fileformat/LambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/fileformat/LambdaRunner.scala
@@ -8,6 +8,6 @@ object LambdaRunner extends App {
     private val body = """{"consignmentId": "907d547d-a9ed-45f3-b93c-055fc792a299", "fileId": "b634337e-5a63-42f4-b97e-4fb9d1c1d366", "originalPath": "testfilesnoeicar/deliberately_unidentifiable_file.dat", "userId": "030cf12c-8d5d-46b9-b86a-38e0920d0e1a"}"""
     val inputStream = new ByteArrayInputStream(body.getBytes())
     private val output = new ByteArrayOutputStream()
-    Lambda().process(inputStream, output)
+    new Lambda().process(inputStream, output)
     println(output.toByteArray.map(_.toChar).mkString)
 }

--- a/src/test/resources/json/ffid_event_missing_original_path.json
+++ b/src/test/resources/json/ffid_event_missing_original_path.json
@@ -1,0 +1,1 @@
+{"consignmentId":  "f0a73877-6057-4bbb-a1eb-7c7b73cab586", "fileId":  "acea5919-25a3-4c6b-8908-fa47cc77878f", "userId":  "9a5f9f7e-0e1d-4bc6-8c81-a7d305acf324"}

--- a/src/test/resources/json/ffid_event_missing_user_id.json
+++ b/src/test/resources/json/ffid_event_missing_user_id.json
@@ -1,0 +1,1 @@
+{"consignmentId":  "f0a73877-6057-4bbb-a1eb-7c7b73cab586", "fileId":  "acea5919-25a3-4c6b-8908-fa47cc77878f", "originalPath" :  "originalPath.{suffix}"}


### PR DESCRIPTION
Require zero argument constructor for Lambdas

Rework the unit tests to test the file format identification in the FFIDExtractor tests as can pass in a DROID api instance

Lambda unit tests test the input stream only